### PR TITLE
Expand channelbits to avoid array overrun and possible stack corruption.

### DIFF
--- a/fano.c
+++ b/fano.c
@@ -61,7 +61,7 @@ struct node {
  * and easier than trying to pack them more compactly.
  */
 int encode(
-    unsigned char *symbols,	// Output buffer, 2*nbytes
+    unsigned char *symbols,	// Output buffer, 2*8*nbytes
     unsigned char *data,		// Input buffer, nbytes
     unsigned int nbytes) {	// Number of bytes in data
     unsigned long encstate;

--- a/wsprsim_utils.c
+++ b/wsprsim_utils.c
@@ -300,7 +300,7 @@ int get_wspr_channel_symbols(char* rawmessage, char* hashtab, unsigned char* sym
 //    printf("Will decode as: %s\n",check_call_loc_pow);
 
     unsigned int nbytes=11; // The message with tail is packed into 11 bytes.
-    unsigned int nencoded=162;
+    unsigned int nencoded=(nbytes * 2 * 8);  // This is how much encode() writes
     unsigned char channelbits[nencoded];
     memset(channelbits,0,sizeof(char)*nencoded);
 


### PR DESCRIPTION
The encode function in fano.c writes to (2*8*nbytes) chars of symbols.
1) Correct the comment in fano.c to show correct number
2) Make the size of channelbits in get_wspr_channel_symbols() large enough by using the formula instead of a constant.  

With the smaller value encode was writing past the end of the array which caused stack corruption on my system.