### PR TITLE
Fix/typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-This project aim at decoding FT8 signals using an RTL device, usually connected to a Raspeberry Pi.
+This project aim at decoding FT8 signals using an RTL device, usually connected to a Raspberry Pi.
 To install and use your dongle on a Raspberry Pi with a Rasberian OS:
 
 ```
@@ -16,7 +16,7 @@ rtlsdr_wsprd -f 2m -c A1XYZ -l AB12cd -g 29
 
 ## Overview
 
-This non-interactive application allows automatic reporting of WSPR spots on WSPRnet. The initial idea was to allow a small computer like a Raspberry Pi and a RTL-SDR device to sent WSPR reports for VHF/UHF bands. This kind of lightweight setup could run continuously without maintenance and help to get additional propagation reports. The code is massively based on Steven Franke (K9AN) implementation of Joe Taylor (K1JT) publication and work.
+This non-interactive application allows automatic reporting of WSPR spots on WSPRnet. The initial idea was to allow a small computer like a Raspberry Pi and a RTL-SDR device to send WSPR reports for VHF/UHF bands. This kind of lightweight setup could run continuously without maintenance and help to get additional propagation reports. The code is massively based on Steven Franke (K9AN) implementation of Joe Taylor (K1JT) publication and work.
 
 This application written in C does:
 
@@ -59,7 +59,7 @@ This application written in C does:
     /opt/vc/bin/tvservice -o
     ```
   - Remove unused modules (for example, /etc/modules: #snd-bcm2835)
-  - Use an enclose, and ground it
+  - Use an enclosure, and ground it
 
 
 ## Crystal stability

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## TL;DR
 
 This project aim at decoding FT8 signals using an RTL device, usually connected to a Raspeberry Pi.
-To install and use your dongle on a Rasberry Pi with a Rasberian OS:
+To install and use your dongle on a Raspberry Pi with a Rasberian OS:
 
 ```
 sudo apt-get -y install build-essential cmake libfftw3-dev libusb-1.0-0-dev librtlsdr-dev libcurl4-gnutls-dev
@@ -16,7 +16,7 @@ rtlsdr_wsprd -f 2m -c A1XYZ -l AB12cd -g 29
 
 ## Overview
 
-This non-interactive application allows automatic reporting of WSPR spots on WSPRnet. The inital idea was to allow a small computer like a Raspberry Pi and a RTL-SDR device to sent WSPR reports for VHF/UHF bands. This kind of lightweight setup could run continuously without maintenance and help to get additionnal propagation reports. The code is massively based on Steven Franke (K9AN) implementation of Joe Taylor (K1JT) publication and work.
+This non-interactive application allows automatic reporting of WSPR spots on WSPRnet. The initial idea was to allow a small computer like a Raspberry Pi and a RTL-SDR device to sent WSPR reports for VHF/UHF bands. This kind of lightweight setup could run continuously without maintenance and help to get additional propagation reports. The code is massively based on Steven Franke (K9AN) implementation of Joe Taylor (K1JT) publication and work.
 
 This application written in C does:
 
@@ -45,7 +45,7 @@ This application written in C does:
      make
      make install
      ```
-  1. Start the application with your right paramaters, ex. for the 2m band, with a fake callsign (A1XYZ):
+  1. Start the application with your right parameters, ex. for the 2m band, with a fake callsign (A1XYZ):
      ```
      rtlsdr_wsprd -f 2m -c A1XYZ -l AB12cd -g 29
      ```
@@ -66,7 +66,7 @@ This application written in C does:
 
 Most of RTL dongles use a cheap crystal, and frequency drift can effect the decoding & performance. The use of no-name RTL dongle for VHF/UHF bands usually require crystal modification, for a better one. External clock could be also used, like GPSDO or rubidium reference clock, aligned on 28.8MHz.
 
-Some manufacturers intergrate a 0.5ppm TCXO. It's the best second option, after an external clock. Based on my personnal experience:
+Some manufacturers intergrate a 0.5ppm TCXO. It's the best second option, after an external clock. Based on my personal experience:
 
 - NooElec NESDR SMART : Works fine out of the box
 - RTL-SDR Blog 1PPM TCXO : Works with some drift, require additional mass, or a better enclosure

--- a/rtlsdr_wsprd.c
+++ b/rtlsdr_wsprd.c
@@ -316,7 +316,7 @@ static void *wsprDecoder(void *arg) {
         pthread_mutex_unlock(&dec.ready_mutex);
 
         if (rx_state.exit_flag)
-            /* Abord case, final sig */
+            /* Abort case, final sig */
             break;
 
         /* Lock the buffer access and make a local copy */
@@ -820,7 +820,7 @@ int main(int argc, char **argv) {
         /* Use the Store the date at the begin of the frame */
         time(&rawtime);
         gtm = gmtime(&rawtime);
-        // FIXME: Complier warning about mixing int & date
+        // FIXME: Compiler warning about mixing int & date
         snprintf(rx_options.date, sizeof(rx_options.date), "%02d%02d%02d", gtm->tm_year - 100, gtm->tm_mon + 1, gtm->tm_mday);
         snprintf(rx_options.uttime, sizeof(rx_options.uttime), "%02d%02d", gtm->tm_hour, gtm->tm_min);
 


### PR DESCRIPTION
codespell (Python based) is another tool that you may want to add to CI.

Sometimes it shows false positives on names of variables, that's why I added "--ignore-words-list rcall" to the command line.