### PR TITLE
Container image

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,46 @@
+name: Container Images
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Calculate Container Metadata
+        id: meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Images
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64, linux/386, linux/arm64, linux/arm/v6, linux/arm/v7
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# -------------------
+# The build container
+# -------------------
+FROM debian:bullseye-slim AS build
+
+RUN apt-get update && \
+  apt-get -y --no-install-recommends install \
+    build-essential \
+    clang \
+    cmake \
+    libcurl4-openssl-dev \
+    libfftw3-dev \
+    libusb-1.0-0-dev \
+    pkg-config \
+    unzip && \
+  rm -rf /var/lib/apt/lists/*
+
+ADD https://github.com/steve-m/librtlsdr/archive/master.zip /root/librtlsdr-master.zip
+RUN unzip /root/librtlsdr-master.zip -d /root && \
+  rm /root/librtlsdr-master.zip && \
+  cd /root/librtlsdr-master && \
+  mkdir -p /root/librtlsdr-master/build && \
+  cd /root/librtlsdr-master/build && \
+  cmake -Wno-dev ../ && \
+  make && \
+  make install && \
+  rm -rf /root/librtlsdr-master
+
+COPY . /root/rtlsdr-wsprd
+
+RUN cd /root/rtlsdr-wsprd && \
+  make && \
+  make install
+
+# -------------------------
+# The application container
+# -------------------------
+FROM debian:bullseye-slim
+
+RUN apt-get update && \
+  apt-get -y --no-install-recommends install \
+   	libcurl4 \
+    libfftw3-single3 \
+    usbutils && \
+  rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /usr/local/lib/librtlsdr.so.0 /usr/local/lib/librtlsdr.so.0
+COPY --from=build /usr/local/bin/rtlsdr_wsprd /usr/local/bin/rtlsdr_wsprd
+RUN ldconfig
+
+ENTRYPOINT ["/usr/local/bin/rtlsdr_wsprd"]

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ This application written in C does:
 ## Installation
 
   1. Install a Linux compatible distro on your device.
-     
+
      For Raspberry Pi, you can download official images [here](https://www.raspberrypi.com/software/operating-systems/).
-  
+
   2. It's a good practice to update your OS. With Pi OS, run this command as usual:
      ```bash
      sudo apt-get update && sudo apt-get upgrade
@@ -66,7 +66,7 @@ This application written in C does:
      ```bash
      sudo apt-get update && sudo apt-get -y install build-essential clang cmake libfftw3-dev libusb-1.0-0-dev libcurl4-gnutls-dev ntp git
      ```
-  
+
   4. Install `rtl-sdr` library manually. **Do not use the `librtlsdr-dev` package on Raspberry PiOS**. There is a know bug with this lib and rtlsdr_wsprd will not be able to get enough samples (don't decode anything & 100% CPU pattern).
      ```bash
      git clone https://github.com/osmocom/rtl-sdr
@@ -79,23 +79,32 @@ This application written in C does:
      cd ../..
      ```
   Note: You may have to re-plug you dongle if it was already connected, or play with `udev` if not automatically detected.
-  
+
   5. Clone this repository:
      ```bash
      git clone https://github.com/Guenael/rtlsdr-wsprd
      ```
-  
+
   6. Build the application:
      ```bash
      cd rtlsdr-wsprd
      make
      sudo make install
      ```
-  
+
   7. Finally, start the application with the right parameters/options for you (frequency, callsign, locator etc... Fake example below):
      ```bash
      rtlsdr_wsprd -f 2m -c A1XYZ -l AB12cd -g 29
      ```
+
+## Container Image
+
+As an alterative to the above steps, a pre-built container image containing rtlsdr-wsprd is available for use with [Docker](https://www.docker.com/) or [Podman](https://podman.io/).
+
+Start the container with the right parameters/options for you (frequency, callsign, locator etc... Fake example below):
+```bash
+docker run --rm -it --device=/dev/bus/usb ghcr.io/Guenael/rtlsdr-wsprd:latest -f 2m -c A1XYZ -l AB12cd -g 29
+```
 
 ## Tips (for your Raspberry Pi and SDR dongles)
 


### PR DESCRIPTION
This PR contains a `Dockerfile` for rtlsdr-wsprd as well as a GitHub Actions Workflow to automatically build and publish container images based on this to GitHub Container Registry.

Newly tagged versions/releases of rtlsdr-wsprd will be automatically published as `latest`, with the `master` Git branch being published as `master` for those who wish to use the latest development version of rtlsdr-wsprd