### PR TITLE
Lowercase repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ If the `modprobe -r` command errors, a reboot is recommended to unload the modul
 You can then start the container with the right parameters/options for you (frequency, callsign, locator etc... Fake example below):
 
 ```bash
-docker run --rm -it --device=/dev/bus/usb ghcr.io/Guenael/rtlsdr-wsprd:latest -f 2m -c A1XYZ -l AB12cd -g 29
+docker run --rm -it --device=/dev/bus/usb ghcr.io/guenael/rtlsdr-wsprd:latest -f 2m -c A1XYZ -l AB12cd -g 29
 ```
 
 ## Tips (for your Raspberry Pi and SDR dongles)

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ If the `modprobe -r` command errors, a reboot is recommended to unload the modul
 You can then start the container with the right parameters/options for you (frequency, callsign, locator etc... Fake example below):
 
 ```bash
-docker run --rm -it --device=/dev/bus/usb ghcr.io/guenael/rtlsdr-wsprd:latest -f 2m -c A1XYZ -l AB12cd -g 29
+docker run --rm -it --pull=always --device=/dev/bus/usb ghcr.io/guenael/rtlsdr-wsprd:latest -f 2m -c A1XYZ -l AB12cd -g 29
 ```
 
 ## Tips (for your Raspberry Pi and SDR dongles)


### PR DESCRIPTION
The container image name needs to be lowercase to avoid the following error:

```
$ docker pull ghcr.io/Guenael/rtlsdr-wsprd:main
invalid reference format: repository name must be lowercase
```

Confirmed it works with lowercase:

```
$ docker pull ghcr.io/guenael/rtlsdr-wsprd:main
main: Pulling from guenael/rtlsdr-wsprd
968621624b32: Pull complete
d8fc8032a2e5: Pull complete
867a66624e86: Pull complete
9f18d8313274: Pull complete
5ad43376fc20: Pull complete
Digest: sha256:9e906c42245179bc4d0c708db6d5a7cf9d5911ec9d7a8fbf8e8dfcaae4cc8e2c
Status: Downloaded newer image for ghcr.io/guenael/rtlsdr-wsprd:main
```

Also made a small change to the example command to ensure the latest image is always used. This will only re-download it if it has changed.