### PR TITLE
Feature/read files

### DIFF
--- a/rtlsdr_wsprd.c
+++ b/rtlsdr_wsprd.c
@@ -518,26 +518,9 @@ int32_t readRawIQfile(float *iSamples, float *qSamples, char *filename) {
         return 0;
     }
 
-    /* Get the size of the file */
-    fseek(fd, 0L, SEEK_END);
-    int32_t recsize = ftell(fd) / (2 * sizeof(float));
-    fseek(fd, 0L, SEEK_SET);
-
-
-    /* Limit the file/buffer to the max samples */
-    if (recsize > SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE) {
-        recsize = SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE;
-    }
-
     /* Read the IQ file */
-    int32_t nread = fread(filebuffer, sizeof(float), 2 * recsize, fd);
-    if (nread != 2 * recsize) {
-        fprintf(stderr, "Cannot read all the data! %d\n", nread);
-        fclose(fd);
-        return 0;
-    } else {
-        fclose(fd);
-    }
+    int32_t nread = fread(filebuffer, sizeof(float), 2 * SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE, fd);
+    int32_t recsize = nread / 2;
 
     /* Convert the interleaved buffer into 2 buffers */
     for (int32_t i = 0; i < recsize; i++) {
@@ -604,16 +587,6 @@ int32_t readC2file(float *iSamples, float *qSamples, char *filename) {
         return 0;
     }
 
-    /* Get the size of the file */
-    fseek(fd, 0L, SEEK_END);
-    int32_t recsize = (ftell(fd) - 26) / (2 * sizeof(float));
-    fseek(fd, 0L, SEEK_SET);
-
-    /* Limit the file/buffer to the max samples */
-    if (recsize > SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE) {
-        recsize = SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE;
-    }
-
     /* Read the header */
     nread = fread(name, sizeof(char), 14, fd);
     nread = fread(&type, sizeof(int), 1, fd);
@@ -621,14 +594,8 @@ int32_t readC2file(float *iSamples, float *qSamples, char *filename) {
     rx_options.dialfreq = frequency;
 
     /* Read the IQ file */
-    nread = fread(filebuffer, sizeof(float), 2 * recsize, fd);
-    if (nread != 2 * recsize) {
-        fprintf(stderr, "Cannot read all the data! %d\n", nread);
-        fclose(fd);
-        return 0;
-    } else {
-        fclose(fd);
-    }
+    nread = fread(filebuffer, sizeof(float), 2 * SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE, fd);
+    int32_t recsize = nread / 2;
 
     /* Convert the interleaved buffer into 2 buffers */
     for (int32_t i = 0; i < recsize; i++) {

--- a/rtlsdr_wsprd.c
+++ b/rtlsdr_wsprd.c
@@ -606,7 +606,7 @@ int32_t readC2file(float *iSamples, float *qSamples, char *filename) {
 
     /* Get the size of the file */
     fseek(fd, 0L, SEEK_END);
-    int32_t recsize = ftell(fd) / (2 * sizeof(float)) - 26;
+    int32_t recsize = (ftell(fd) - 26) / (2 * sizeof(float));
     fseek(fd, 0L, SEEK_SET);
 
     /* Limit the file/buffer to the max samples */


### PR DESCRIPTION
One commit of this PR is the same as the one in PR #118.

I think that the current code is too complicated and that it's uncommon that `fread()` read less than what found with `fseek()`+`ftell()`, but then the code reads any short file, as it should, since chances are that some signals would be decoded anyway thanks to error correction, eg. with half of [211212_2142.zip](https://github.com/Guenael/rtlsdr-wsprd/files/7740060/211212_2142.zip) rtlsdr_wsprd can decode the same signal as with the full file:
```
$ dd if=211212_2142.c2 of=half_211212_2142.c2 ibs=1 count=180026
$ ./rtlsdr_wsprd [...]
Reading IQ file: c2/half_211212_2142.c2
Number of samples: 22500
        SNR      DT        Freq Dr    Call    Loc Pwr
Spot : -15.08  -0.08   7.040093  0   M0ICR   IO91 27
```
A message about less samples than expected would be useful.

Avoiding the use of `fseek()` would allow to read the files from a pipe or `/dev/stdin` (if the check for file extensions allowed that), like was asked in issue #20.
