### PR TITLE
Aligned print spots without seconds

### DIFF
--- a/rtlsdr_wsprd.c
+++ b/rtlsdr_wsprd.c
@@ -448,13 +448,12 @@ void printSpots(uint32_t n_results) {
     }
 
     for (uint32_t i = 0; i < n_results; i++) {
-        printf("Spot :  %04d-%02d-%02d %02d:%02d:%02d %6.2f %6.2f %10.6f %2d %7s %6s %2s\n",
+        printf("Spot :  %04d-%02d-%02d %02d:%02dz %6.2f %6.2f %10.6f %2d %7s %6s %2s\n",
                rx_state.gtm->tm_year + 1900,
                rx_state.gtm->tm_mon + 1,
                rx_state.gtm->tm_mday,
                rx_state.gtm->tm_hour,
                rx_state.gtm->tm_min,
-               rx_state.gtm->tm_sec,
                dec_results[i].snr,
                dec_results[i].dt,
                dec_results[i].freq,
@@ -1139,7 +1138,7 @@ int main(int argc, char **argv) {
     uint32_t usec  = sec * 1000000 + lTime.tv_usec;
     uint32_t uwait = 120000000 - usec;
     printf("Wait for time sync (start in %d sec)\n\n", uwait / 1000000);
-    printf("              Date  Time(z)    SNR     DT       Freq Dr    Call    Loc Pwr\n");
+    printf("              Date   Time    SNR     DT       Freq Dr    Call    Loc Pwr\n");
 
     /* Prepare a low priority param for the decoder thread */
     struct sched_param param;


### PR DESCRIPTION
In most outputs we specify `z` as UTC timezone, but for spots we show seconds which in my opinions is meaningless. 
Thus, I changed a little output format by removing seconds and `z` in title as time already contain it.

```
              Date   Time    SNR     DT       Freq Dr    Call    Loc Pwr
Spot :  2024-02-26 10:42z -22.92  -0.89  14.097205  0  OH8GKP   KP24 33
No spot 2024-02-26 10:44z
Spot :  2024-02-26 10:46z -18.87  -1.19  14.097079  0   G0IDE   IO83 37
Spot :  2024-02-26 10:46z -26.21  -0.93  14.097162  0   HA4BM   JO22 27
No spot 2024-02-26 10:48z
No spot 2024-02-26 10:50z
```