### PR TITLE
Fix whitespace padding for PWR

### DIFF
--- a/wsprd/wsprd_utils.c
+++ b/wsprd/wsprd_utils.c
@@ -263,7 +263,7 @@ int unpk_(signed char *message, char *hashtab, char *loctab, char *call_loc_pow,
         if (nu == 0 || nu == 3 || nu == 7) {
             ndbm = ntype;
             memset(call_loc_pow, 0, sizeof(char) * 23);
-            sprintf(cdbm, "%2d", ndbm);
+            sprintf(cdbm, "%02d", ndbm);
             strncat(call_loc_pow, callsign, strlen(callsign));
             strncat(call_loc_pow, " ", 1);
             strncat(call_loc_pow, grid, 4);


### PR DESCRIPTION
In some cases WSPR decodes signal power less than 10.
`wsprd_utils.c` has simple coverter from decimal to string `sprintf(cdbm, "%2d", ndbm);`. This works without issue for values bigger than 10. On the other side, some station transmit with values less than 10 or oven with 0 dBm power.

Than we use this value like ` 0` (whitespace with zero) to build request url using `%s` formatting.
As a result, url contains invalid value like `&dbm= 0` and curl cannot perform this request.

Here is simplifies error log.
```
              Date   Time    SNR     DT       Freq Dr    Call    Loc Pwr
Spot :  2024-02-29 15:14z -14.54  -0.78  14.097040  0  DB1IAT   JN48 00
Decoder thread -- Sending spot using this URL: http://wsprnet.org/post?function=wspr&rcall=SP2RM&rgrid=JO94hj&rqrg=14.097038&date=240229&time=1356&sig=-20&dt=-0.6&tqrg=14.097038&tcall=DB1IAT&tgrid=JN48&dbm= 0&version=rtlsdr-054&mode=2
curl_easy_perform() failed: URL using bad/illegal format or missing URL
```

I checked that wsprnet.org respets values like `&dbm=01` or `&dbm=00`   without issues, thus I added zero padding.

```
> curl -X POST 'http://wsprnet.org/post?function=wspr&rcall=EW1IM&rgrid=JO94hj&rqrg=14.097038&date=240229&time=1354&sig=-20&dt=-0.6&tqrg=14.097038&tcall=DB1IAT&tgrid=JN48&dbm=%200&version=rtlsdr-054&mode=2'
<html>

<body>
  1 out of 1 spot(s) added<br>
Processing took 107 milliseconds.<br>
</body>
```

The second solution is to escape this particular PWR value using `curl_easy_escape` before formatting (building) url.