### PR TITLE
support for macos

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,11 +2,13 @@
 *.o
 *.d
 *.iq
+*.cf32
+*.cu8
 art/
 .github
 documentation/
 CLAUDE.md
 PLAN.md
 RAPPORT.md
-selftest.iq
+selftest.cf32
 tests/test_wsprd

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.d
 *.a
 *.iq
+*.cf32
+*.cu8
 *.c2
 rtlsdr_wsprd
 tests/test_wsprd

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ test: all tests/test_wsprd
 -include $(DEPS)
 
 clean:
-	rm -f *.o wsprd/*.o tests/*.o *.d wsprd/*.d tests/*.d $(TARGETS) tests/test_wsprd fftw_wisdom.dat hashtable.txt selftest.iq
+	rm -f *.o wsprd/*.o tests/*.o *.d wsprd/*.d tests/*.d $(TARGETS) tests/test_wsprd fftw_wisdom.dat hashtable.txt selftest.cf32
 
 install:
 	install rtlsdr_wsprd /usr/local/bin/rtlsdr_wsprd

--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,12 @@ DEPS = $(OBJS:.o=.d) $(TEST_OBJS:.o=.d)
 
 TARGETS = rtlsdr_wsprd
 
-.PHONY: all clean install test
+.PHONY: all debug clean install test
 
 all: $(TARGETS)
+
+debug: CFLAGS += -O0 -g -DLOG_LEVEL=0
+debug: $(TARGETS)
 
 %.o: %.c
 	${CC} ${CFLAGS} $(EXTRA_OPTS) -c $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,17 @@ CC ?= clang
 CFLAGS = -O3 -std=gnu17 -Wall -Wextra -Wno-unused-parameter -MMD
 LIBS = -lusb-1.0 -lrtlsdr -lpthread -lfftw3f -lcurl -lm
 
+# Homebrew support (macOS)
+HOMEBREW_PREFIX := $(shell brew --prefix 2>/dev/null)
+ifneq ($(HOMEBREW_PREFIX),)
+	CFLAGS += -I$(HOMEBREW_PREFIX)/include
+	LDFLAGS += -L$(HOMEBREW_PREFIX)/lib
+	# Bake the rpath so the binary finds librtlsdr without DYLD tricks.
+	# /usr/local/lib covers the user's existing install; homebrew prefix covers
+	# Apple Silicon (/opt/homebrew/lib) or Intel (/usr/local/lib).
+	LDFLAGS += -Wl,-rpath,/usr/local/lib -Wl,-rpath,$(HOMEBREW_PREFIX)/lib
+endif
+
 # Note
 #   gcc is a bit faster that clang on this app
 #   for dbg: -fsanitize=address

--- a/rtlsdr_wsprd.c
+++ b/rtlsdr_wsprd.c
@@ -638,7 +638,8 @@ int32_t readRawIQfile(float *iSamples, float *qSamples, const char *filename) {
         return 0;
     }
 
-    /* Read the IQ file */
+    /* Read cf32 (complex float32) interleaved IQ file — compatible with
+       inspectrum, GNU Radio, and other SDR tools expecting this format. */
     int32_t nread = fread(filebuffer, sizeof(float), 2 * SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE, fd);
     int32_t recsize = nread / 2;
     fclose(fd);
@@ -1137,13 +1138,13 @@ int main(int argc, char **argv) {
     }
 
     if (rx_options.readfile == true) {
-        fprintf(stdout, "Reading IQ file: %s\n", rx_options.filename);
+        fprintf(stdout, "Reading cf32/IQ file: %s\n", rx_options.filename);
         decodeRecordedFile(rx_options.filename);
         return EXIT_SUCCESS;
     }
 
     if (rx_options.writefile == true) {
-        fprintf(stdout, "Saving IQ file planned with prefix: %.8s\n", rx_options.filename);
+        fprintf(stdout, "Saving cf32 file planned with prefix: %.8s\n", rx_options.filename);
     }
 
     if (rx_options.writerawfile == true) {

--- a/rtlsdr_wsprd.c
+++ b/rtlsdr_wsprd.c
@@ -103,9 +103,18 @@ struct receiver_options {
     bool     noreport;
     bool     selftest;
     bool     writefile;
+    bool     writerawfile;
     bool     readfile;
     char     *filename;
+    char     *rawfilename;
 };
+
+
+/* Raw pre-downsampling capture state (shared: written by rtlsdr thread,
+   rotated by main thread). */
+static FILE *rawFP = NULL;
+static volatile bool rawRotateRequested = false;
+static uint64_t rawSamplesWritten = 0;  /* IQ pairs written in current file */
 
 
 /* states & options are shared with other external objects */
@@ -122,6 +131,70 @@ const char wsprnet_app_version[]  = "rtlsdr-056";  // 10 chars max.!
 
 /* Callback for each buffer received */
 static void rtlsdr_callback(unsigned char *samples, uint32_t samples_count, void *ctx) {
+    /* Raw pre-downsampling capture: write the original unsigned 8-bit IQ
+       samples (RTL-SDR native "cu8" format) straight to disk, before the
+       in-place fs/4 mixer below mutates `samples`. cu8 is the wire format
+       the dongle produces; dumping it as-is is 4x smaller than cf32 and
+       is directly readable by rtl_* tools and inspectrum. */
+    if (rx_options.writerawfile) {
+        if (rawRotateRequested || rawFP == NULL) {
+            if (rawFP) {
+                LOG(LOG_DEBUG, "raw capture -- closing file after %llu IQ pairs (%.2f s @ %u sps)\n",
+                    (unsigned long long)rawSamplesWritten,
+                    (double)rawSamplesWritten / SAMPLING_RATE, SAMPLING_RATE);
+                fclose(rawFP);
+                rawFP = NULL;
+            }
+            rawRotateRequested = false;
+            rawSamplesWritten = 0;
+
+            char rawname[64];
+            time_t rawtime;
+            time(&rawtime);
+            struct tm *gtm = gmtime(&rawtime);
+            snprintf(rawname, sizeof(rawname) - 1,
+                     "%.8s_%04d-%02d-%02d_%02d-%02d-%02d.raw.cu8",
+                     rx_options.rawfilename,
+                     gtm->tm_year + 1900, gtm->tm_mon + 1, gtm->tm_mday,
+                     gtm->tm_hour, gtm->tm_min, gtm->tm_sec);
+            rawFP = fopen(rawname, "wb");
+            if (!rawFP) {
+                fprintf(stderr, "raw capture -- cannot open %s\n", rawname);
+                rx_options.writerawfile = false;
+            } else {
+                /* Passband info: the tuner LO is set to realfreq + FS4_RATE + 1500,
+                   so DC of the raw stream = realfreq + FS4_RATE + 1500 Hz, and it
+                   spans +/- SAMPLING_RATE/2 around that. */
+                uint32_t lo_hz  = rx_options.realfreq + FS4_RATE + 1500;
+                double   lo_mhz = lo_hz / 1e6;
+                double   span   = SAMPLING_RATE / 1e6;
+                fprintf(stderr,
+                        "raw capture -- opened %s\n"
+                        "                LO (DC) = %.6f MHz  (dial %u Hz + %d Hz offset)\n"
+                        "                sample rate = %u sps (interleaved cu8, unsigned 8-bit)\n"
+                        "                passband = [%.6f .. %.6f] MHz (span %.3f MHz)\n"
+                        "                WSPR window = [%.6f .. %.6f] MHz (dial+1400..+1600 Hz)\n",
+                        rawname, lo_mhz, rx_options.dialfreq,
+                        (int)(lo_hz - rx_options.dialfreq),
+                        SAMPLING_RATE,
+                        lo_mhz - span/2.0, lo_mhz + span/2.0, span,
+                        (rx_options.dialfreq + 1400) / 1e6,
+                        (rx_options.dialfreq + 1600) / 1e6);
+            }
+        }
+        if (rawFP) {
+            size_t nw = fwrite(samples, sizeof(unsigned char), samples_count, rawFP);
+            if (nw != samples_count) {
+                fprintf(stderr, "raw capture -- short write, disabling\n");
+                fclose(rawFP);
+                rawFP = NULL;
+                rx_options.writerawfile = false;
+            } else {
+                rawSamplesWritten += samples_count / 2;
+            }
+        }
+    }
+
     int8_t *sigIn = (int8_t *)samples;
 
     /* CIC buffers/vars */
@@ -347,6 +420,7 @@ void initrx_options() {
     rx_options.device         = 0;
     rx_options.selftest       = false;
     rx_options.writefile      = false;
+    rx_options.writerawfile   = false;
     rx_options.readfile       = false;
     rx_options.noreport       = false;
 }
@@ -480,7 +554,7 @@ void saveSample(float *iSamples, float *qSamples) {
         time(&rawtime);
         struct tm *gtm = gmtime(&rawtime);
 
-        snprintf(filename, sizeof(filename) - 1, "%.8s_%04d-%02d-%02d_%02d-%02d-%02d.iq",
+        snprintf(filename, sizeof(filename) - 1, "%.8s_%04d-%02d-%02d_%02d-%02d-%02d.cf32",
                  rx_options.filename,
                  gtm->tm_year + 1900,
                  gtm->tm_mon + 1,
@@ -700,12 +774,13 @@ void decodeRecordedFile(const char *filename) {
     int32_t n_results = 0;
 
     size_t fnlen = strlen(filename);
-    if (fnlen >= 3 && strcmp(&filename[fnlen-3], ".iq") == 0) {
+    if ((fnlen >= 3 && strcmp(&filename[fnlen-3], ".iq") == 0) ||
+        (fnlen >= 5 && strcmp(&filename[fnlen-5], ".cf32") == 0)) {
         samples_len = readRawIQfile(iSamples, qSamples, filename);
     } else if (fnlen >= 3 && strcmp(&filename[fnlen-3], ".c2") == 0) {
         samples_len = readC2file(iSamples, qSamples, filename);
     } else {
-        fprintf(stderr, "Not a valid extension!! (only .iq & .c2 files)\n");
+        fprintf(stderr, "Not a valid extension!! (only .iq, .cf32 & .c2 files)\n");
         return;
     }
 
@@ -787,7 +862,7 @@ int32_t decoderSelfTest() {
     }
 
     /* Save the test sample */
-    writeRawIQfile(iSamples, qSamples, "selftest.iq");
+    writeRawIQfile(iSamples, qSamples, "selftest.cf32");
 
     /* Search & decode the signal */
     wspr_decode(iSamples, qSamples, samples_len, dec_options, dec_results, &n_results);
@@ -841,9 +916,11 @@ void usage(FILE *stream, int32_t status) {
             "\t-x do not report any spots on web clusters (WSPRnet, PSKreporter...)\n"
             "Debugging options:\n"
             "\t-t decoder self-test (generate a signal & decode), no parameter\n"
-            "\t-w write received signal and exit [filename prefix]\n"
-            "\t-r read signal with .iq or .c2 format, decode and exit [filename]\n"
-            "\t   (raw format: 375sps, float 32 bits, 2 channels)\n"
+            "\t-w write decimated signal (375 sps cf32) after each frame [filename prefix]\n"
+            "\t-W also write raw pre-downsampling capture (2.4 Msps cu8) [filename prefix]\n"
+            "\t   (one file per 2-min frame; ~576 MB/file, native RTL format)\n"
+            "\t-r read signal with .cf32, .iq or .c2 format, decode and exit [filename]\n"
+            "\t   (-w/-r raw format: 375sps, float 32 bits, 2 channels interleaved)\n"
             "Other options:\n"
             "\t--help show list of options\n"
             "\t--version show version of program\n"
@@ -860,7 +937,7 @@ int main(int argc, char **argv) {
     curl_global_init(CURL_GLOBAL_ALL);
 
     uint32_t opt;
-    char    *short_options = "f:c:l:g:ao:p:u:d:n:i:tw:r:HQSx";
+    char    *short_options = "f:c:l:g:ao:p:u:d:n:i:tw:W:r:HQSx";
     int32_t  option_index = 0;
     struct option long_options[] = {
         {"help",    no_argument, 0, 0 },
@@ -1010,6 +1087,10 @@ int main(int argc, char **argv) {
                 rx_options.writefile = true;
                 rx_options.filename = optarg;
                 break;
+            case 'W':  // Also write raw pre-downsampling cu8 capture
+                rx_options.writerawfile = true;
+                rx_options.rawfilename = optarg;
+                break;
             case 'r':  // Read a signal and decode
                 rx_options.readfile = true;
                 rx_options.filename = optarg;
@@ -1063,6 +1144,29 @@ int main(int argc, char **argv) {
 
     if (rx_options.writefile == true) {
         fprintf(stdout, "Saving IQ file planned with prefix: %.8s\n", rx_options.filename);
+    }
+
+    if (rx_options.writerawfile == true) {
+        uint32_t lo_hz  = rx_options.realfreq + FS4_RATE + 1500;
+        double   span   = SAMPLING_RATE / 1e6;
+        fprintf(stdout,
+                "Saving raw pre-downsampling capture with prefix: %.8s\n"
+                "  format      : interleaved cu8 (unsigned 8-bit I,Q)\n"
+                "  sample rate : %u sps\n"
+                "  tuner LO    : %.6f MHz (= DC in capture)\n"
+                "  dial freq   : %.6f MHz (= DC - %d Hz)\n"
+                "  passband    : [%.6f .. %.6f] MHz (span %.3f MHz)\n"
+                "  WSPR window : [%.6f .. %.6f] MHz (dial+1400..+1600 Hz)\n"
+                "  file size   : ~%llu MB per 2-minute frame\n",
+                rx_options.rawfilename,
+                SAMPLING_RATE,
+                lo_hz / 1e6,
+                rx_options.dialfreq / 1e6,
+                (int)(lo_hz - rx_options.dialfreq),
+                lo_hz / 1e6 - span/2.0, lo_hz / 1e6 + span/2.0, span,
+                (rx_options.dialfreq + 1400) / 1e6,
+                (rx_options.dialfreq + 1600) / 1e6,
+                (unsigned long long)(120ULL * SAMPLING_RATE * 2ULL / (1024ULL * 1024ULL)));
     }
 
     /* If something goes wrong... */
@@ -1218,6 +1322,9 @@ int main(int argc, char **argv) {
         /* Switch to the other buffer and trigger the decoder */
         rx_state.bufferIndex = (rx_state.bufferIndex + 1) % 2;
         rx_state.iqIndex[rx_state.bufferIndex] = 0;
+        if (rx_options.writerawfile) {
+            rawRotateRequested = true;  /* callback closes & reopens on its next entry */
+        }
         safe_cond_signal(&decState.ready_cond, &decState.ready_mutex);
         usleep(100000); /* Give a chance to the other thread to update the nloop counter */
     }
@@ -1237,6 +1344,15 @@ int main(int argc, char **argv) {
     /* Destroy the lock/cond/thread */
     pthread_cond_destroy(&decState.ready_cond);
     pthread_mutex_destroy(&decState.ready_mutex);
+
+    /* Close any open raw capture file (the RX thread has stopped by now). */
+    if (rawFP) {
+        LOG(LOG_DEBUG, "raw capture -- closing final file after %llu IQ pairs (%.2f s)\n",
+            (unsigned long long)rawSamplesWritten,
+            (double)rawSamplesWritten / SAMPLING_RATE);
+        fclose(rawFP);
+        rawFP = NULL;
+    }
 
     curl_global_cleanup();
     printf("Bye!\n");

--- a/rtlsdr_wsprd.c
+++ b/rtlsdr_wsprd.c
@@ -168,7 +168,7 @@ static void rtlsdr_callback(unsigned char *samples, uint32_t samples_count, void
        (Keep the upper band, IQ inverted on RTL devices)
     */
     int8_t tmp;
-    for (uint32_t i = 0; i < samples_count; i += 8) {
+    for (uint32_t i = 0; i + 7 < samples_count; i += 8) {
         sigIn[i  ] ^=  0x80;  // Unsigned to signed conversion using
         sigIn[i+1] ^=  0x80;  //   XOR as a binary mask to flip the first bit
         tmp         =  (sigIn[i+3] ^ 0x80);
@@ -553,23 +553,30 @@ int32_t parse_u64(char *s, uint64_t *const value) {
 
 
 int32_t readRawIQfile(float *iSamples, float *qSamples, const char *filename) {
-    float filebuffer[2 * SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE];
-    FILE *fd = fopen(filename, "rb");
+    float *filebuffer = malloc(sizeof(float) * 2 * SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE);
+    if (!filebuffer) {
+        fprintf(stderr, "Cannot allocate memory for IQ buffer\n");
+        return 0;
+    }
 
+    FILE *fd = fopen(filename, "rb");
     if (fd == NULL) {
         fprintf(stderr, "Cannot open data file...\n");
+        free(filebuffer);
         return 0;
     }
 
     /* Read the IQ file */
     int32_t nread = fread(filebuffer, sizeof(float), 2 * SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE, fd);
     int32_t recsize = nread / 2;
+    fclose(fd);
 
     /* Convert the interleaved buffer into 2 buffers */
     for (int32_t i = 0; i < recsize; i++) {
         iSamples[i] =  filebuffer[2 * i];
         qSamples[i] = -filebuffer[2 * i + 1];  // neg, convention used by wsprsim
     }
+    free(filebuffer);
 
     /* Normalize the sample @-3dB */
     float maxSig = 1e-24f;
@@ -583,7 +590,7 @@ int32_t readRawIQfile(float *iSamples, float *qSamples, const char *filename) {
             maxSig = absQ;
     }
     maxSig = 0.5 / maxSig;
-    for (int i = 0; i <recsize; i++) {
+    for (int i = 0; i < recsize; i++) {
         iSamples[i] *= maxSig;
         qSamples[i] *= maxSig;
     }
@@ -593,11 +600,16 @@ int32_t readRawIQfile(float *iSamples, float *qSamples, const char *filename) {
 
 
 int32_t writeRawIQfile(float *iSamples, float *qSamples, const char *filename) {
-    float filebuffer[2 * SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE];
+    float *filebuffer = malloc(sizeof(float) * 2 * SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE);
+    if (!filebuffer) {
+        fprintf(stderr, "Cannot allocate memory for IQ buffer\n");
+        return 0;
+    }
 
     FILE *fd = fopen(filename, "wb");
     if (fd == NULL) {
         fprintf(stderr, "Cannot open data file...\n");
+        free(filebuffer);
         return 0;
     }
 
@@ -607,8 +619,10 @@ int32_t writeRawIQfile(float *iSamples, float *qSamples, const char *filename) {
     }
 
     int32_t nwrite = fwrite(filebuffer, sizeof(float), 2 * SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE, fd);
+    free(filebuffer);
     if (nwrite != 2 * SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE) {
         fprintf(stderr, "Cannot write all the data!\n");
+        fclose(fd);
         return 0;
     }
 
@@ -618,7 +632,12 @@ int32_t writeRawIQfile(float *iSamples, float *qSamples, const char *filename) {
 
 
 int32_t readC2file(float *iSamples, float *qSamples, const char *filename) {
-    float filebuffer[2 * SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE];
+    float *filebuffer = malloc(sizeof(float) * 2 * SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE);
+    if (!filebuffer) {
+        fprintf(stderr, "Cannot allocate memory for IQ buffer\n");
+        return 0;
+    }
+
     FILE *fd = fopen(filename, "rb");
     int32_t nread;
     double frequency;
@@ -627,6 +646,7 @@ int32_t readC2file(float *iSamples, float *qSamples, const char *filename) {
 
     if (fd == NULL) {
         fprintf(stderr, "Cannot open data file...\n");
+        free(filebuffer);
         return 0;
     }
 
@@ -639,12 +659,14 @@ int32_t readC2file(float *iSamples, float *qSamples, const char *filename) {
     /* Read the IQ file */
     nread = fread(filebuffer, sizeof(float), 2 * SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE, fd);
     int32_t recsize = nread / 2;
+    fclose(fd);
 
     /* Convert the interleaved buffer into 2 buffers */
     for (int32_t i = 0; i < recsize; i++) {
         iSamples[i] =  filebuffer[2 * i];
         qSamples[i] = -filebuffer[2 * i + 1];  // neg, convention used by wsprsim
     }
+    free(filebuffer);
 
     /* Normalize the sample @-3dB */
     float maxSig = 1e-24f;
@@ -658,7 +680,7 @@ int32_t readC2file(float *iSamples, float *qSamples, const char *filename) {
             maxSig = absQ;
     }
     maxSig = 0.5 / maxSig;
-    for (int i = 0; i <recsize; i++) {
+    for (int i = 0; i < recsize; i++) {
         iSamples[i] *= maxSig;
         qSamples[i] *= maxSig;
     }
@@ -673,9 +695,10 @@ void decodeRecordedFile(const char *filename) {
     static uint32_t samples_len;
     int32_t n_results = 0;
 
-    if (strcmp(&filename[strlen(filename)-3], ".iq") == 0) {
+    size_t fnlen = strlen(filename);
+    if (fnlen >= 3 && strcmp(&filename[fnlen-3], ".iq") == 0) {
         samples_len = readRawIQfile(iSamples, qSamples, filename);
-    } else if (strcmp(&filename[strlen(filename)-3], ".c2") == 0) {
+    } else if (fnlen >= 3 && strcmp(&filename[fnlen-3], ".c2") == 0) {
         samples_len = readC2file(iSamples, qSamples, filename);
     } else {
         fprintf(stderr, "Not a valid extension!! (only .iq & .c2 files)\n");
@@ -827,6 +850,11 @@ void usage(FILE *stream, int32_t status) {
 
 
 int main(int argc, char **argv) {
+    /* Must be called once on the main thread before any background thread
+       calls curl_easy_init(); otherwise macOS SSL/DNS init is not thread-safe
+       and causes random Bus Errors. */
+    curl_global_init(CURL_GLOBAL_ALL);
+
     uint32_t opt;
     char    *short_options = "f:c:l:g:ao:p:u:d:n:i:tw:r:HQSx";
     int32_t  option_index = 0;
@@ -1150,21 +1178,27 @@ int main(int argc, char **argv) {
     printf("Wait for time sync (start in %d sec)\n\n", uwait / 1000000);
     printf("              Date   Time    SNR     DT       Freq Dr    Call    Loc Pwr\n");
 
-    /* Prepare a low priority param for the decoder thread */
-    struct sched_param param;
-    pthread_attr_init(&decState.tattr);
-    pthread_attr_setschedpolicy(&decState.tattr, SCHED_RR);
-    pthread_attr_getschedparam(&decState.tattr, &param);
-    param.sched_priority = 90;  // = sched_get_priority_min();
-    pthread_attr_setschedparam(&decState.tattr, &param);
-
     /* Create a thread and stuff for separate decoding
        Info : https://computing.llnl.gov/tutorials/pthreads/
+       Note: SCHED_RR requires root on macOS and causes pthread_create to fail
+       silently for normal users, leaving decState.thread uninitialized and
+       crashing pthread_join at exit. Use default attributes instead.
     */
     pthread_cond_init(&decState.ready_cond, NULL);
     pthread_mutex_init(&decState.ready_mutex, NULL);
     pthread_create(&dongle, NULL, rtlsdr_rx, NULL);
-    pthread_create(&decState.thread, &decState.tattr, decoder, NULL);
+
+    /* Explicitly set stack size to 8MB (macOS default is 512KB; Linux is 8MB).
+       wspr_decode() uses large heap allocations but also has significant frame
+       depth; without this the decoder thread hits the guard page immediately. */
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setstacksize(&attr, 8 * 1024 * 1024);
+    if (pthread_create(&decState.thread, &attr, decoder, NULL) != 0) {
+        fprintf(stderr, "Failed to create decoder thread\n");
+        exit(EXIT_FAILURE);
+    }
+    pthread_attr_destroy(&attr);
 
     /* Main loop : Wait, read, decode */
     while (!rx_state.exit_flag && !(rx_options.maxloop && (rx_options.nloop >= rx_options.maxloop))) {
@@ -1200,6 +1234,7 @@ int main(int argc, char **argv) {
     pthread_cond_destroy(&decState.ready_cond);
     pthread_mutex_destroy(&decState.ready_mutex);
 
+    curl_global_cleanup();
     printf("Bye!\n");
 
     return EXIT_SUCCESS;

--- a/rtlsdr_wsprd.c
+++ b/rtlsdr_wsprd.c
@@ -258,7 +258,7 @@ static void rtlsdr_callback(unsigned char *samples, uint32_t samples_count, void
              * Understanding cascaded integrator-comb filters
                https://www.embedded.com/design/configurable-systems/4006446/Understanding-cascaded-integrator-comb-filters
     */
-    for (int32_t i = 0; i < samples_count / 2; i++) {
+    for (uint32_t i = 0; i < samples_count / 2; i++) {
         /* Integrator stages (N=2) */
         Ix1 += (int32_t)sigIn[i * 2];
         Qx1 += (int32_t)sigIn[i * 2 + 1];
@@ -791,7 +791,7 @@ void decodeRecordedFile(const char *filename) {
         wspr_decode(iSamples, qSamples, samples_len, dec_options, dec_results, &n_results);
 
         printf("        SNR      DT        Freq Dr    Call    Loc Pwr\n");
-        for (uint32_t i = 0; i < n_results; i++) {
+        for (int32_t i = 0; i < n_results; i++) {
             printf("Spot : %6.2f %6.2f %10.6f %2d %7s %6s %2s\n",
                    dec_results[i].snr,
                    dec_results[i].dt,
@@ -868,7 +868,7 @@ int32_t decoderSelfTest() {
     wspr_decode(iSamples, qSamples, samples_len, dec_options, dec_results, &n_results);
 
     printf("        SNR      DT        Freq Dr    Call    Loc Pwr\n");
-    for (uint32_t i = 0; i < n_results; i++) {
+    for (int32_t i = 0; i < n_results; i++) {
         printf("Spot(%i) %6.2f %6.2f %10.6f %2d %7s %6s %2s\n",
                i,
                dec_results[i].snr,
@@ -936,7 +936,7 @@ int main(int argc, char **argv) {
        and causes random Bus Errors. */
     curl_global_init(CURL_GLOBAL_ALL);
 
-    uint32_t opt;
+    int opt;
     char    *short_options = "f:c:l:g:ao:p:u:d:n:i:tw:W:r:HQSx";
     int32_t  option_index = 0;
     struct option long_options[] = {
@@ -1185,7 +1185,7 @@ int main(int argc, char **argv) {
     }
 
     fprintf(stderr, "Found %d device(s):\n", rtl_count);
-    for (uint32_t i = 0; i < rtl_count; i++) {
+    for (int32_t i = 0; i < rtl_count; i++) {
         rtlsdr_get_device_usb_strings(i, rtl_vendor, rtl_product, rtl_serial);
         fprintf(stderr, "  %d:  %s, %s, SN: %s\n", i, rtl_vendor, rtl_product, rtl_serial);
     }

--- a/rtlsdr_wsprd.c
+++ b/rtlsdr_wsprd.c
@@ -43,17 +43,15 @@
 #define FIR_TAPS            32
 
 
-/* Debugging logs */
-#define LOG_DEBUG   0
-#define LOG_INFO    1
-#define LOG_WARN    2
-#define LOG_ERROR   3
-#define LOG_LEVEL   LOG_ERROR
-#define LOG(level, ...)  if (level >= LOG_LEVEL) fprintf(stderr, __VA_ARGS__)
-
-
 #define safe_cond_signal(n, m) pthread_mutex_lock(m); pthread_cond_signal(n); pthread_mutex_unlock(m)
 #define safe_cond_wait(n, m) pthread_mutex_lock(m); pthread_cond_wait(n, m); pthread_mutex_unlock(m)
+
+
+/* Forward declarations (kept static to this TU) */
+static void rtlsdr_callback(unsigned char *samples, uint32_t samples_count, void *ctx);
+static void sigint_callback_handler(int signum);
+static void *rtlsdr_rx(void *arg);
+static void *decoder(void *arg);
 
 
 /* Thread for decoding */
@@ -570,6 +568,9 @@ int32_t readRawIQfile(float *iSamples, float *qSamples, const char *filename) {
     int32_t nread = fread(filebuffer, sizeof(float), 2 * SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE, fd);
     int32_t recsize = nread / 2;
     fclose(fd);
+    LOG(LOG_DEBUG, "readRawIQfile('%s'): read %d floats -> %d IQ pairs (expected %d pairs = %d s @ %d sps)\n",
+        filename, nread, recsize,
+        SIGNAL_LENGHT * SIGNAL_SAMPLE_RATE, SIGNAL_LENGHT, SIGNAL_SAMPLE_RATE);
 
     /* Convert the interleaved buffer into 2 buffers */
     for (int32_t i = 0; i < recsize; i++) {
@@ -589,11 +590,14 @@ int32_t readRawIQfile(float *iSamples, float *qSamples, const char *filename) {
         if (absQ > maxSig)
             maxSig = absQ;
     }
+    float preNormMax = maxSig;
     maxSig = 0.5 / maxSig;
     for (int i = 0; i < recsize; i++) {
         iSamples[i] *= maxSig;
         qSamples[i] *= maxSig;
     }
+    LOG(LOG_DEBUG, "readRawIQfile: pre-norm max|I|,|Q|=%.3g  scale=%.3g  post-norm peak=0.5\n",
+        preNormMax, maxSig);
 
     return recsize;
 }

--- a/rtlsdr_wsprd.h
+++ b/rtlsdr_wsprd.h
@@ -20,12 +20,8 @@
 #pragma once
 
 #include <unistd.h>
-
-#ifndef bool
-    typedef uint32_t bool;
-    #define true 1
-    #define false 0
-#endif
+#include <stdbool.h>
+#include <stdint.h>
 
 
 static void rtlsdr_callback(unsigned char *samples, uint32_t samples_count, void *ctx);

--- a/rtlsdr_wsprd.h
+++ b/rtlsdr_wsprd.h
@@ -19,15 +19,23 @@
 
 #pragma once
 
+#include <stdio.h>
 #include <unistd.h>
 #include <stdbool.h>
 #include <stdint.h>
 
 
-static void rtlsdr_callback(unsigned char *samples, uint32_t samples_count, void *ctx);
-static void sigint_callback_handler(int signum);
-static void *rtlsdr_rx(void *arg);
-static void *decoder(void *arg);
+/* Debugging logs */
+#define LOG_DEBUG   0
+#define LOG_INFO    1
+#define LOG_WARN    2
+#define LOG_ERROR   3
+#ifndef LOG_LEVEL
+#define LOG_LEVEL   LOG_ERROR
+#endif
+#define LOG(level, ...)  if (level >= LOG_LEVEL) fprintf(stderr, __VA_ARGS__)
+
+
 void initSampleStorage();
 void initrx_options();
 void initDecoder_options();

--- a/wsprd/wsprd.c
+++ b/wsprd/wsprd.c
@@ -642,6 +642,22 @@ int wspr_decode(float  *idat,
 
         qsort(candidates, npk, sizeof(struct cand), cand_snr_desc);
 
+        /* DC spike rejection: RTL-SDR LO leakage produces a strong false
+           peak near 0 Hz.  After sorting by SNR, check if the top candidate
+           is suspiciously close to DC and far stronger than the runner-up. */
+        if (npk >= 2 &&
+            fabsf(candidates[0].freq) <= DC_REJECT_BW &&
+            (candidates[0].snr - candidates[1].snr) >= DC_REJECT_MARGIN) {
+            /* Shift array down by one, dropping the DC candidate. */
+            for (int k = 0; k < npk - 1; k++)
+                candidates[k] = candidates[k + 1];
+            npk--;
+        } else if (npk == 1 &&
+                   fabsf(candidates[0].freq) <= DC_REJECT_BW &&
+                   candidates[0].snr >= DC_REJECT_MARGIN) {
+            npk = 0;
+        }
+
         /* Make coarse estimates of shift (DT), freq, and drift
          * Look for time offsets up to +/- 8 symbols (about +/- 5.4 s) relative
            to nominal start time, which is 2 seconds into the file
@@ -750,6 +766,7 @@ int wspr_decode(float  *idat,
 
             int idt = 0, ii = 0;
             int not_decoded = 1;
+            int consecutive_timeouts = 0;
             while (worth_a_try && not_decoded && idt <= (128 / iifac)) {
                 ii = (idt + 1) / 2;
                 if (idt % 2 == 1) ii = -ii;
@@ -771,9 +788,23 @@ int wspr_decode(float  *idat,
                     deinterleave(symbols);
                     not_decoded = fano(&metric, &cycles, &maxnp, decdata, symbols, NBITS,
                                        mettab, delta, maxcycles);
+                    if (not_decoded) {
+                        /* Detect Fano timeout: cycles >= maxcycles*NBITS means the
+                           decoder hit the wall without converging. */
+                        if (cycles >= (unsigned int)maxcycles * NBITS) {
+                            consecutive_timeouts++;
+                            if (consecutive_timeouts >= MAX_JIGGER_TIMEOUTS) {
+                                break;
+                            }
+                        } else {
+                            consecutive_timeouts = 0;  /* partial progress, reset */
+                        }
+                    } else {
+                        consecutive_timeouts = 0;
+                    }
                 }
                 idt++;
-                if (options.quickmode) 
+                if (options.quickmode)
                     break;
             }
 

--- a/wsprd/wsprd.c
+++ b/wsprd/wsprd.c
@@ -33,10 +33,12 @@
 
 #include <math.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <fftw3.h>
 
+#include "../rtlsdr_wsprd.h"
 #include "./wsprd.h"
 #include "./fano.h"
 #include "./nhash.h"
@@ -529,10 +531,15 @@ int wspr_decode(float  *idat,
         return -1;
     }
 
+    LOG(LOG_DEBUG, "wspr_decode: samples=%d npasses=%d quickmode=%d subtraction=%d usehashtable=%d\n",
+        samples, options.npasses, options.quickmode, options.subtraction, options.usehashtable);
+
     /* Main loop starts here */
     for (int ipass = 0; ipass < options.npasses; ipass++) {
         if (ipass == 1 && uniques == 0)
             break;
+        LOG(LOG_DEBUG, "--- Pass %d (maxdrift=%d minsync1=%.3f minsync2=%.3f) ---\n",
+            ipass, (ipass < 2) ? 4 : 0, minsync1, (ipass < 2) ? 0.12f : 0.10f);
         if (ipass < 2) {
             maxdrift = 4;
             minsync2 = 0.12;
@@ -630,6 +637,8 @@ int wspr_decode(float  *idat,
             }
         }
 
+        int npk_before_band = npk;
+
         // Don't waste time on signals outside of the range [fmin,fmax].
         int i = 0;
         for (int j = 0; j < npk; j++) {
@@ -645,9 +654,13 @@ int wspr_decode(float  *idat,
         /* DC spike rejection: RTL-SDR LO leakage produces a strong false
            peak near 0 Hz.  After sorting by SNR, check if the top candidate
            is suspiciously close to DC and far stronger than the runner-up. */
+        int npk_before_dc = npk;
         if (npk >= 2 &&
             fabsf(candidates[0].freq) <= DC_REJECT_BW &&
             (candidates[0].snr - candidates[1].snr) >= DC_REJECT_MARGIN) {
+            LOG(LOG_DEBUG, "Pass %d: rejecting DC spike: freq=%+.2f Hz  snr=%.2f dB (next=%.2f dB, delta=%.1f dB)\n",
+                ipass, candidates[0].freq, candidates[0].snr, candidates[1].snr,
+                candidates[0].snr - candidates[1].snr);
             /* Shift array down by one, dropping the DC candidate. */
             for (int k = 0; k < npk - 1; k++)
                 candidates[k] = candidates[k + 1];
@@ -655,7 +668,16 @@ int wspr_decode(float  *idat,
         } else if (npk == 1 &&
                    fabsf(candidates[0].freq) <= DC_REJECT_BW &&
                    candidates[0].snr >= DC_REJECT_MARGIN) {
+            LOG(LOG_DEBUG, "Pass %d: rejecting lone DC spike: freq=%+.2f Hz  snr=%.2f dB\n",
+                ipass, candidates[0].freq, candidates[0].snr);
             npk = 0;
+        }
+
+        LOG(LOG_DEBUG, "Pass %d: noise_level=%.3g  peaks=%d  in-band[%.0f..%.0f Hz]=%d  after-dc=%d\n",
+            ipass, noise_level, npk_before_band, fmin, fmax, npk_before_dc, npk);
+        for (int c = 0; c < npk && c < 10; c++) {
+            LOG(LOG_DEBUG, "  cand[%2d] freq=%+7.2f Hz  snr=%6.2f dB\n",
+                c, candidates[c].freq, candidates[c].snr);
         }
 
         /* Make coarse estimates of shift (DT), freq, and drift
@@ -722,6 +744,9 @@ int wspr_decode(float  *idat,
          could each work on one candidate at a time.
          */
 
+        int dbg_gate_sync1 = 0, dbg_tried = 0, dbg_gate_sync2 = 0, dbg_gate_rms = 0,
+            dbg_fano_fail = 0, dbg_fano_ok = 0, dbg_dupes = 0, dbg_noprint = 0;
+
         for (int j = 0; j < npk; j++) {
             memset(callsign, 0, sizeof(char) * 13);
             memset(call_loc_pow, 0, sizeof(char) * 23);
@@ -733,6 +758,7 @@ int wspr_decode(float  *idat,
             float drift = candidates[j].drift;
             float sync  = candidates[j].sync;
             int   shift = candidates[j].shift;
+            float coarse_sync = sync;
 
             // Search for best sync lag (mode 0)
             fstep = 0.0;
@@ -760,8 +786,12 @@ int wspr_decode(float  *idat,
 
             if (sync > minsync1) {
                 worth_a_try = 1;
+                dbg_tried++;
             } else {
                 worth_a_try = 0;
+                dbg_gate_sync1++;
+                LOG(LOG_DEBUG, "  [%3d] freq=%+7.2f  coarse_sync=%.3f  refined_sync=%.3f < minsync1=%.3f  SKIP\n",
+                    j, candidates[j].freq, coarse_sync, sync, minsync1);
             }
 
             int idt = 0, ii = 0;
@@ -788,12 +818,18 @@ int wspr_decode(float  *idat,
                     deinterleave(symbols);
                     not_decoded = fano(&metric, &cycles, &maxnp, decdata, symbols, NBITS,
                                        mettab, delta, maxcycles);
+                    LOG(LOG_DEBUG, "  [%3d] freq=%+7.2f  jigger=%+3d  sync=%.3f  rms=%.2f  fano: %s  cycles=%u metric=%u\n",
+                        j, freq, ii, sync, rms,
+                        not_decoded ? "FAIL" : "OK", cycles, metric);
                     if (not_decoded) {
+                        dbg_fano_fail++;
                         /* Detect Fano timeout: cycles >= maxcycles*NBITS means the
                            decoder hit the wall without converging. */
                         if (cycles >= (unsigned int)maxcycles * NBITS) {
                             consecutive_timeouts++;
                             if (consecutive_timeouts >= MAX_JIGGER_TIMEOUTS) {
+                                LOG(LOG_DEBUG, "  [%3d] bail: %d consecutive Fano timeouts, abandoning candidate\n",
+                                    j, consecutive_timeouts);
                                 break;
                             }
                         } else {
@@ -802,6 +838,11 @@ int wspr_decode(float  *idat,
                     } else {
                         consecutive_timeouts = 0;
                     }
+                } else {
+                    if (!(sync > minsync2)) dbg_gate_sync2++;
+                    if (!(rms > minrms))   dbg_gate_rms++;
+                    LOG(LOG_DEBUG, "  [%3d] freq=%+7.2f  jigger=%+3d  sync=%.3f (min=%.3f)  rms=%.2f (min=%.2f)  gated, no fano\n",
+                        j, freq, ii, sync, minsync2, rms, minrms);
                 }
                 idt++;
                 if (options.quickmode)
@@ -809,6 +850,7 @@ int wspr_decode(float  *idat,
             }
 
             if (worth_a_try && !not_decoded) {
+                dbg_fano_ok++;
                 for (i = 0; i < 11; i++) {
                     if (decdata[i] > 127) {
                         message[i] = decdata[i] - 256;
@@ -821,6 +863,9 @@ int wspr_decode(float  *idat,
                 // sanity checks on grid and power, and return
                 // call_loc_pow string and also callsign (for de-duping).
                 int32_t noprint = unpk_(message, hashtab, loctab, call_loc_pow, call, loc, pwr, callsign);
+                LOG(LOG_DEBUG, "  [%3d] unpk_ -> noprint=%d  call='%s'  loc='%s'  pwr='%s'  msg='%s'\n",
+                    j, noprint, call, loc, pwr, call_loc_pow);
+                if (noprint) dbg_noprint++;
                 if (options.subtraction && (ipass == 0) && !noprint) {
                     unsigned char channel_symbols[NSYM];
 
@@ -841,6 +886,7 @@ int wspr_decode(float  *idat,
                     if (!strcmp(callsign, allcalls[i]) && (fabs(freq - allfreqs[i]) < 3.0))
                         dupe = 1;
                 }
+                if (dupe) dbg_dupes++;
 
                 if (!dupe) {
                     snprintf(allcalls[uniques], sizeof(allcalls[0]), "%s", callsign);
@@ -864,7 +910,13 @@ int wspr_decode(float  *idat,
                 }
             }
         }
+
+        LOG(LOG_DEBUG, "Pass %d summary: candidates=%d  sync1_skip=%d  tried=%d  sync2_gate=%d  rms_gate=%d  fano_fail=%d  fano_ok=%d  noprint=%d  dupes=%d  uniques_total=%d\n",
+            ipass, npk, dbg_gate_sync1, dbg_tried, dbg_gate_sync2, dbg_gate_rms,
+            dbg_fano_fail, dbg_fano_ok, dbg_noprint, dbg_dupes, uniques);
     }
+
+    LOG(LOG_DEBUG, "wspr_decode done: %d unique decode(s)\n", uniques);
 
     /* Sort the result */
     qsort(decodes, uniques, sizeof(struct decoder_results), results_snr_desc);

--- a/wsprd/wsprd.c
+++ b/wsprd/wsprd.c
@@ -472,11 +472,16 @@ int wspr_decode(float  *idat,
         mettab[1][i] = roundf(10.0 * (metric_tables[2][255 - i] - bias));
     }
 
-    /* Setup/Load hash tables */
+    /* Setup/Load hash tables (heap to avoid ~585KB on stack) */
     FILE  *fhash;
     int   nh;
-    char  hashtab[HASHTAB_SIZE * HASHTAB_ENTRY_LEN] = {0};
-    char  loctab[HASHTAB_SIZE * LOCTAB_ENTRY_LEN] = {0};
+    char  *hashtab = calloc(HASHTAB_SIZE, HASHTAB_ENTRY_LEN);
+    char  *loctab  = calloc(HASHTAB_SIZE, LOCTAB_ENTRY_LEN);
+    if (!hashtab || !loctab) {
+        free(hashtab);
+        free(loctab);
+        return -1;
+    }
 
     if (options.usehashtable) {
         char line[80], hcall[12], hgrid[5];;
@@ -512,10 +517,17 @@ int wspr_decode(float  *idat,
         hann[i] = sinf(0.006147931 * i);
     }
 
-    /* FFT output alloc */
+    /* FFT output alloc (heap to avoid stack overflow with ~715KB VLA) */
     const int blocks = 4 * floor(samples / FFT_SIZE) - 1;
-    float ps[FFT_SIZE][blocks];
-    memset(ps, 0.0, sizeof(float) * FFT_SIZE * blocks);
+    float (*ps)[blocks] = calloc(FFT_SIZE, sizeof(float[blocks]));
+    if (!ps) {
+        free(hashtab);
+        free(loctab);
+        fftwf_free(fftin);
+        fftwf_free(fftout);
+        fftwf_destroy_plan(PLAN);
+        return -1;
+    }
 
     /* Main loop starts here */
     for (int ipass = 0; ipass < options.npasses; ipass++) {
@@ -654,7 +666,7 @@ int wspr_decode(float  *idat,
                         for (int k = 0; k < NSYM; k++) {  // Sum over symbols
                             int ifd = ifr + ((float)k - (float)NBITS) / (float)NBITS * ((float)idrift) / DF;
                             int kindex = k0 + 2 * k;
-                            if (kindex < blocks) {
+                            if (kindex < blocks && ifd >= 3 && ifd + 3 < FFT_SIZE) {
                                 float p0 = sqrtf(ps[ifd - 3][kindex]);
                                 float p1 = sqrtf(ps[ifd - 1][kindex]);
                                 float p2 = sqrtf(ps[ifd + 1][kindex]);
@@ -829,6 +841,7 @@ int wspr_decode(float  *idat,
     /* Return number of spots to the calling fct */
     *n_results = uniques;
 
+    free(ps);
     fftwf_free(fftin);
     fftwf_free(fftout);
 
@@ -850,6 +863,9 @@ int wspr_decode(float  *idat,
             fclose(fhash);
         }
     }
+
+    free(hashtab);
+    free(loctab);
 
     return 0;
 }

--- a/wsprd/wsprd.h
+++ b/wsprd/wsprd.h
@@ -40,6 +40,20 @@
 #define MAX_CANDIDATES     200
 #define MAX_UNIQUES        100
 
+/* DC spike rejection: skip candidates within +/- DC_REJECT_BW Hz of DC
+   whose SNR exceeds the next-best candidate by DC_REJECT_MARGIN dB.
+   RTL-SDR devices commonly leak the LO into the digitised stream,
+   producing a strong false peak at exactly 0 Hz offset. */
+#define DC_REJECT_BW       2.0f    /* Hz half-width around DC */
+#define DC_REJECT_MARGIN   15.0f   /* dB above the next candidate */
+
+/* Maximum consecutive Fano timeouts per candidate before abandoning the
+   jigger loop early.  A real signal occasionally times out on one offset
+   but succeeds on the next; a DC spike or spurious peak times out on
+   every attempt.  3 is a good balance: it still gives a real marginal
+   signal a few chances while cutting the worst-case ~43-iteration burn. */
+#define MAX_JIGGER_TIMEOUTS 3
+
 /* Option & config of decoder (Shared with the wsprd code) */
 struct decoder_options {
     int  freq;          // Dial frequency


### PR DESCRIPTION
Tested on aarch64 macos, need to test on x86_64 ubuntu still, but should be fine. Fixes some lint, moves some variables from stack to heap, and fixes libcurl init. Throws `bus error` on attempted decode without these patches.